### PR TITLE
Range assumptions for byte and word inputs

### DIFF
--- a/circuits/cert_verify.circom
+++ b/circuits/cert_verify.circom
@@ -31,6 +31,10 @@ include "ca.circom"; // Include the hardcoded CA certificate chain.
 /// @param len The length of the input array.
 ///
 /// @note Must be aligned with 8 bytes!
+///
+/// Assumption: Each element in `buf` must already be constrained to lie in the 0–255 range (i.e., be a byte).
+/// This template does not enforce the byte-range constraint itself to avoid duplicate constraints
+/// when used in combination with helpers like `reverse_bytes`.
 template bytes_to_qword(len) {
   assert(len % 8 == 0);
 

--- a/circuits/helper.circom
+++ b/circuits/helper.circom
@@ -45,6 +45,11 @@ template qwords_to_bytes(len) {
   }
 }
 
+// Reverses a byte array in place.
+// 
+// Assumption: Each element in `in` must already be constrained to lie in the 0–255 range (i.e., be a byte).
+// This template does not enforce this range check to avoid duplicating constraints
+// when used in combination with other helpers like `bytes_to_qword`.
 template reverse_bytes(len) {
   signal input in[len];
   signal output out[len];

--- a/circuits/rsa.circom
+++ b/circuits/rsa.circom
@@ -57,6 +57,19 @@ template xor_byte() {
 // 2. H = SHA384(padding1 || M' || salt)
 // 3. maskedDB = (padding_2 || salt) ^ MGF(H, 48) (^ is xor)
 // 4. sig = maskedDB || H || 0xbc
+//
+// Assumptions:
+// - Each element of `sign` is a `w`-bit limb (i.e., 0 <= sign[i] < 2^w)
+// - Each element of `modulus` is a `w`-bit limb (i.e., 0 <= modulus[i] < 2^w)
+//
+// These constraints are not enforced in this template. The caller (e.g., `validate_x509_rsa`)
+// must ensure that each element of `sign` and `modulus` is properly constrained to `w` bits.
+// This choice is intentional for performance reasons: the inputs may already be range-checked
+// on the caller's side (as is indeed the case in `validate_x509_rsa`), and duplicating those checks
+// here would unnecessarily increase the number of constraints.
+//
+// Only the `message_hashed` input signal is range-checked, as it is passed as input 
+// to `Sha384_hash_bytes_digest`, which internally applies `ToBits(8)` to each element.
 template RsaVerifySsaPss(w, nb, e_bits, hashLen) {
     signal input sign[nb];
     signal input modulus[nb];


### PR DESCRIPTION
This pull request addresses three issues related to missing range checks. Specifically, the following issues have been resolved:

* **[#4: Missing range checks in `reverse_bytes` \[Severity: High\]](https://github.com/tiktok-privacy-innovation/trustless-attestation-verification-circom/issues/4)**
  A comment was added to document that each input element must already be constrained to the 0–255 range. This avoids duplicating byte constraints when used in conjunction with other helpers such as `bytes_to_qword`.

* **[#5: Missing range checks in `bytes_to_qword` \[Severity: High\]](https://github.com/tiktok-privacy-innovation/trustless-attestation-verification-circom/issues/5)**
  A similar comment was added to clarify that the input array must contain only bytes.

* **[#14: Underconstrained signals in `RsaVerifySsaPss` \[Severity: High\]](https://github.com/tiktok-privacy-innovation/trustless-attestation-verification-circom/issues/14)**
  The assumption that all `sign` and `modulus` limbs must be constrained to `w` bits is now clearly documented. These constraints are delegated to the caller (e.g., `validate_x509_rsa`) for performance reasons.

For full details, please refer to the linked issue descriptions.
Closes #4, #5, and #14.
