### PR TITLE
Fixed underconstrained signals and removed reversal duplication in signature validator

### DIFF
--- a/circuits/cert_verify.circom
+++ b/circuits/cert_verify.circom
@@ -71,11 +71,14 @@ template validate_x509_rsa(word, number_blocks, e_bits, hash_len, tbs_certificat
   // uint8_t signature[512];
   signal input signature[512];
 
-  // constraining modulus to byte values (0–255).
+  // constraining modulus and signature to byte values (0–255).
   component modulus_bytes[512];
+  component signature_bytes[512];
   for (var i = 0; i < 512; i++) {
     modulus_bytes[i] = Num2Bits(8);
+    signature_bytes[i] = Num2Bits(8);
     modulus_bytes[i].in <== modulus[i];
+    signature_bytes[i].in <== signature[i];
   }
 
   // Modulus needs to be reversed.

--- a/circuits/cert_verify.circom
+++ b/circuits/cert_verify.circom
@@ -81,11 +81,12 @@ template validate_x509_rsa(word, number_blocks, e_bits, hash_len, tbs_certificat
     signature_bytes[i].in <== signature[i];
   }
 
-  // Modulus needs to be reversed.
+  // Modulus needs to be reversed (i.e., converted to little-endian).
   signal modulus_little_endian[512];
-  for (var i = 0; i < 512; i++) {
-    modulus_little_endian[i] <== modulus[511 - i];
-  }
+  component reverse_modulus = reverse_bytes(512);
+  reverse_modulus.in <== modulus;
+  modulus_little_endian <== reverse_modulus.out;
+
   // signature needs to be reversed.
   signal signature_little_endian[512];
   for (var i = 0; i < 512; i++) {

--- a/circuits/cert_verify.circom
+++ b/circuits/cert_verify.circom
@@ -71,6 +71,13 @@ template validate_x509_rsa(word, number_blocks, e_bits, hash_len, tbs_certificat
   // uint8_t signature[512];
   signal input signature[512];
 
+  // constraining modulus to byte values (0–255).
+  component modulus_bytes[512];
+  for (var i = 0; i < 512; i++) {
+    modulus_bytes[i] = Num2Bits(8);
+    modulus_bytes[i].in <== modulus[i];
+  }
+
   // Modulus needs to be reversed.
   signal modulus_little_endian[512];
   for (var i = 0; i < 512; i++) {

--- a/circuits/cert_verify.circom
+++ b/circuits/cert_verify.circom
@@ -87,11 +87,11 @@ template validate_x509_rsa(word, number_blocks, e_bits, hash_len, tbs_certificat
   reverse_modulus.in <== modulus;
   modulus_little_endian <== reverse_modulus.out;
 
-  // signature needs to be reversed.
+  // Signature needs to be reversed (i.e., converted to little-endian).
   signal signature_little_endian[512];
-  for (var i = 0; i < 512; i++) {
-    signature_little_endian[i] <== signature[511 - i];
-  }
+  component reverse_signature = reverse_bytes(512);
+  reverse_signature.in <== signature;
+  signature_little_endian <== reverse_signature.out;
 
   // Convert the modulus and signature into uint64_t arrays.
   component modulus_qwords = bytes_to_qword(512);

--- a/circuits/cert_verify.circom
+++ b/circuits/cert_verify.circom
@@ -31,6 +31,10 @@ include "ca.circom"; // Include the hardcoded CA certificate chain.
 /// @param len The length of the input array.
 ///
 /// @note Must be aligned with 8 bytes!
+///
+/// Assumption: Each element in `buf` must already be constrained to lie in the 0–255 range (i.e., be a byte).
+/// This template does not enforce the byte-range constraint itself to avoid duplicate constraints
+/// when used in combination with helpers like `reverse_bytes`.
 template bytes_to_qword(len) {
   assert(len % 8 == 0);
 

--- a/circuits/helper.circom
+++ b/circuits/helper.circom
@@ -45,6 +45,11 @@ template qwords_to_bytes(len) {
   }
 }
 
+// Reverses a byte array in place.
+// 
+// Assumption: Each element in `in` must already be constrained to lie in the 0–255 range (i.e., be a byte).
+// This template does not enforce this range check to avoid duplicating constraints
+// when used in combination with other helpers like `bytes_to_qword`.
 template reverse_bytes(len) {
   signal input in[len];
   signal output out[len];

--- a/circuits/rsa.circom
+++ b/circuits/rsa.circom
@@ -57,6 +57,19 @@ template xor_byte() {
 // 2. H = SHA384(padding1 || M' || salt)
 // 3. maskedDB = (padding_2 || salt) ^ MGF(H, 48) (^ is xor)
 // 4. sig = maskedDB || H || 0xbc
+//
+// Assumptions:
+// - Each element of `sign` is a `w`-bit limb (i.e., 0 <= sign[i] < 2^w)
+// - Each element of `modulus` is a `w`-bit limb (i.e., 0 <= modulus[i] < 2^w)
+//
+// These constraints are not enforced in this template. The caller (e.g., `validate_x509_rsa`)
+// must ensure that each element of `sign` and `modulus` is properly constrained to `w` bits.
+// This choice is intentional for performance reasons: the inputs may already be range-checked
+// on the caller's side (as is indeed the case in `validate_x509_rsa`), and duplicating those checks
+// here would unnecessarily increase the number of constraints.
+//
+// Only the `message_hashed` input signal is range-checked, as it is passed as input 
+// to `Sha384_hash_bytes_digest`, which internally applies `ToBits(8)` to each element.
 template RsaVerifySsaPss(w, nb, e_bits, hashLen) {
     signal input sign[nb];
     signal input modulus[nb];


### PR DESCRIPTION
This pull request addresses two issues in `validate_x509_rsa`:

* #7
Explicit `Num2Bits(8)` constraints have been added to ensure that the `modulus` and `signature` input arrays are properly constrained to byte values (0–255). Without these checks, invalid values could propagate into downstream cryptographic components and break circuit soundness. The `tbs_certificate` input passes through a SHA-384 component which applies the necessary range checks, so no changes were needed there.

* #8
 The manual for-loops used to reverse the `modulus` and `signature` arrays have been replaced with instances of the `reverse_bytes` helper template.

For full details, please refer to the linked issues.

Closes #7 and #8.
