### PR TITLE
Added missing semicolon in mgf1sha384

### DIFF
--- a/circuits/mgf1sha384.circom
+++ b/circuits/mgf1sha384.circom
@@ -27,7 +27,7 @@ template to_bytes_be(n) {
   signal input in;
   signal output out[n];
 
-  assert(n <= 31)
+  assert(n <= 31);
 
   component to_bits = Num2Bits(n * 8);
   var num[n];


### PR DESCRIPTION
This pull request fixes the following issue:
- #21
  The semicolon was missing from the statement `assert(n <= 31)` causing a circom compile error in `make compile_circuits`. The semicolon has been added.

Closes #21.